### PR TITLE
fix: mem leak in jv_array_indexes

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -406,27 +406,22 @@ int jv_array_contains(jv a, jv b) {
 jv jv_array_indexes(jv a, jv b) {
   jv res = jv_array();
   int idx = -1;
-  jv_array_foreach(a, ai, aelem) {
+  int alen = jv_array_length(jv_copy(a));
+  for (int ai = 0; ai < alen; ++ai) {
     jv_array_foreach(b, bi, belem) {
-      // quieten compiler warnings about aelem not being used... by
-      // using it
-      if ((bi == 0 && !jv_equal(jv_copy(aelem), jv_copy(belem))) ||
-          (bi > 0 && !jv_equal(jv_array_get(jv_copy(a), ai + bi), jv_copy(belem))))
+      if (!jv_equal(jv_array_get(jv_copy(a), ai + bi), belem))
         idx = -1;
       else if (bi == 0 && idx == -1)
         idx = ai;
-      jv_free(belem);
     }
     if (idx > -1)
       res = jv_array_append(res, jv_number(idx));
     idx = -1;
-    jv_free(aelem);
   }
   jv_free(a);
   jv_free(b);
   return res;
 }
-
 
 /*
  * Strings (internal helpers)

--- a/src/jv.c
+++ b/src/jv.c
@@ -415,10 +415,12 @@ jv jv_array_indexes(jv a, jv b) {
         idx = -1;
       else if (bi == 0 && idx == -1)
         idx = ai;
+      jv_free(belem);
     }
     if (idx > -1)
       res = jv_array_append(res, jv_number(idx));
     idx = -1;
+    jv_free(aelem);
   }
   jv_free(a);
   jv_free(b);


### PR DESCRIPTION
The foreach macro calls into jv_array_get for both inner and outer loop which makes a copy of the element hence should be freed.

This fixes the leak when use `index(...)` function in JQ program.